### PR TITLE
Check for existence of window.DOMException before referencing it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -734,7 +734,7 @@ var JsonServiceClient = /** @class */ (function () {
         }).catch(function (error) {
             // No responseStatus body, set from `res` Body object
             if (error instanceof Error
-                || (typeof window != "undefined" && error instanceof window.DOMException /*MS Edge*/)) {
+                || (typeof window != "undefined" && window.DOMException && error instanceof window.DOMException /*MS Edge*/)) {
                 throw _this.raiseError(res, createErrorResponse(res.status, res.statusText, type));
             }
             throw _this.raiseError(res, error);


### PR DESCRIPTION
This issue occurs in React Native where the window object does not contain the DOMException key. 

Error scenario:
- servicestack-client makes post request to service stack endpoint
- endpoint replies with 400 response and no responseStatus body
- servicestack-client checks to see if error is instance of DOMException
- DOMException doesn't exist and new error is thrown
- original error message from endpoint is not bubbled up as usurped by non-existence error