### PR TITLE
Abortable fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@servicestack/client",
-  "version": "1.0.35",
-  "lockfileVersion": 2,
+  "version": "1.0.39",
+  "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,466 @@
 {
   "name": "@servicestack/client",
   "version": "1.0.35",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@servicestack/client",
+      "version": "1.0.35",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es6-shim": "^0.35.4",
+        "eventsource": "^1.0.7",
+        "fetch-everywhere": "^1.0.5"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.1.7",
+        "@types/mocha": "^5.2.5",
+        "abort-controller": "^3.0.0",
+        "chai": "^4.2.0",
+        "fetch-everywhere": "^1.0.5",
+        "mocha": "^5.2.0",
+        "typescript": "^3.2.4"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+      "dev": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
+      "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
+      "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://obrc.pkgs.visualstudio.com/_packaging/PrivateLibs/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dependencies": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "node_modules/es6-shim": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.4.tgz",
+      "integrity": "sha512-oJidbXjN/VWXZJs41E9JEqWzcFbjt43JupimIoVX82Thzt5qy1CiYezdhRmWkj3KOuwJ106IG/ZZrcFC6fgIUQ=="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://obrc.pkgs.visualstudio.com/_packaging/PrivateLibs/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/fetch-everywhere": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fetch-everywhere/-/fetch-everywhere-1.0.5.tgz",
+      "integrity": "sha1-skl/R6V9kCazkHwJdWrPX0vTTos=",
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "dependencies": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dependencies": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
   "dependencies": {
     "@types/chai": {
       "version": "4.1.7",
@@ -15,6 +473,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
       "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://obrc.pkgs.visualstudio.com/_packaging/PrivateLibs/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -117,6 +584,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://obrc.pkgs.visualstudio.com/_packaging/PrivateLibs/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k=",
       "dev": true
     },
     "eventsource": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "publish": "tsc && tsc -p tsconfig.umd.json && move dist\\index.js dist\\servicestack-client.umd.js && bash inject-umd.sh && npm run uglify && move src\\index.js dist && copy src\\index.d.ts dist",
     "dtos": "cd tests/dtos && typescript-ref",
     "test": "mocha -t 5000 ./tests/*.js",
-    "testonly": "mocha -t 5000 ./tests/serverevents.spec.js"
+    "testonly": "mocha -t 5000 ./tests/client.spec.js"
   },
   "files": [
     "dist/index.js",
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.5",
+    "abort-controller": "^3.0.0",
     "chai": "^4.2.0",
     "fetch-everywhere": "^1.0.5",
     "mocha": "^5.2.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -128,7 +128,7 @@ export interface IReconnectServerEventsOptions {
 export declare enum ReadyState {
     CONNECTING = 0,
     OPEN = 1,
-    CLOSED = 2,
+    CLOSED = 2
 }
 export interface IEventSourceStatic extends EventTarget {
     new (url: string, eventSourceInitDict?: IEventSourceInit): IEventSourceStatic;
@@ -284,6 +284,7 @@ export interface ISendRequest {
     returns?: {
         createResponse: () => any;
     };
+    signal?: AbortSignal;
 }
 export declare class JsonServiceClient {
     baseUrl: string;
@@ -312,30 +313,30 @@ export declare class JsonServiceClient {
     constructor(baseUrl?: string);
     setCredentials(userName: string, password: string): void;
     setBearerToken(token: string): void;
-    get<T>(request: IReturn<T> | string, args?: any): Promise<T>;
-    delete<T>(request: IReturn<T> | string, args?: any): Promise<T>;
-    post<T>(request: IReturn<T>, args?: any): Promise<T>;
-    postToUrl<T>(url: string, request: IReturn<T>, args?: any): Promise<T>;
-    postBody<T>(request: IReturn<T>, body: string | any, args?: any): Promise<T>;
-    put<T>(request: IReturn<T>, args?: any): Promise<T>;
-    putToUrl<T>(url: string, request: IReturn<T>, args?: any): Promise<T>;
-    putBody<T>(request: IReturn<T>, body: string | any, args?: any): Promise<T>;
-    patch<T>(request: IReturn<T>, args?: any): Promise<T>;
-    patchToUrl<T>(url: string, request: IReturn<T>, args?: any): Promise<T>;
-    patchBody<T>(request: IReturn<T>, body: string | any, args?: any): Promise<T>;
-    publish(request: IReturnVoid, args?: any): Promise<any>;
-    sendOneWay<T>(request: IReturn<T> | IReturnVoid, args?: any): Promise<T>;
-    sendAll<T>(requests: IReturn<T>[]): Promise<T[]>;
-    sendAllOneWay<T>(requests: IReturn<T>[]): Promise<void>;
+    get<T>(request: IReturn<T> | string, args?: any, signal?: AbortSignal): Promise<T>;
+    delete<T>(request: IReturn<T> | string, args?: any, signal?: AbortSignal): Promise<T>;
+    post<T>(request: IReturn<T>, args?: any, signal?: AbortSignal): Promise<T>;
+    postToUrl<T>(url: string, request: IReturn<T>, args?: any, signal?: AbortSignal): Promise<T>;
+    postBody<T>(request: IReturn<T>, body: string | any, args?: any, signal?: AbortSignal): Promise<T>;
+    put<T>(request: IReturn<T>, args?: any, signal?: AbortSignal): Promise<T>;
+    putToUrl<T>(url: string, request: IReturn<T>, args?: any, signal?: AbortSignal): Promise<T>;
+    putBody<T>(request: IReturn<T>, body: string | any, args?: any, signal?: AbortSignal): Promise<T>;
+    patch<T>(request: IReturn<T>, args?: any, signal?: AbortSignal): Promise<T>;
+    patchToUrl<T>(url: string, request: IReturn<T>, args?: any, signal?: AbortSignal): Promise<T>;
+    patchBody<T>(request: IReturn<T>, body: string | any, args?: any, signal?: AbortSignal): Promise<T>;
+    publish(request: IReturnVoid, args?: any, signal?: AbortSignal): Promise<any>;
+    sendOneWay<T>(request: IReturn<T> | IReturnVoid, args?: any, signal?: AbortSignal): Promise<T>;
+    sendAll<T>(requests: IReturn<T>[], signal?: AbortSignal): Promise<T[]>;
+    sendAllOneWay<T>(requests: IReturn<T>[], signal?: AbortSignal): Promise<void>;
     createUrlFromDto<T>(method: string, request: IReturn<T>): string;
     toAbsoluteUrl(relativeOrAbsoluteUrl: string): string;
     deleteCookie(name: string): void;
-    private createRequest({method, request, url, args, body});
-    private json(res);
-    private createResponse<T>(res, request);
-    private handleError(holdRes, res, type?);
-    send<T>(method: string, request: any | null, args?: any, url?: string): Promise<T>;
-    private sendBody<T>(method, request, body, args?);
+    private createRequest;
+    private json;
+    private createResponse;
+    private handleError;
+    send<T>(method: string, request: any | null, args?: any, url?: string, signal?: AbortSignal): Promise<T>;
+    private sendBody;
     sendRequest<T>(info: ISendRequest): Promise<T>;
     raiseError(res: Response, error: any): any;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -331,12 +331,12 @@ export declare class JsonServiceClient {
     createUrlFromDto<T>(method: string, request: IReturn<T>): string;
     toAbsoluteUrl(relativeOrAbsoluteUrl: string): string;
     deleteCookie(name: string): void;
-    private createRequest;
-    private json;
-    private createResponse;
-    private handleError;
+    private createRequest({method, request, url, args, body});
+    private json(res);
+    private createResponse<T>(res, request);
+    private handleError(holdRes, res, type?);
     send<T>(method: string, request: any | null, args?: any, url?: string, signal?: AbortSignal): Promise<T>;
-    private sendBody;
+    private sendBody<T>(method, request, body, args?, signal?: AbortSignal);
     sendRequest<T>(info: ISendRequest): Promise<T>;
     raiseError(res: Response, error: any): any;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,6 +750,7 @@ export interface ISendRequest
     args?:any; 
     url?:string; 
     returns?: { createResponse: () => any };
+    signal?: AbortSignal
 }
 
 export class JsonServiceClient {
@@ -799,77 +800,77 @@ export class JsonServiceClient {
         this.bearerToken = token;
     }
 
-    get<T>(request: IReturn<T>|string, args?:any): Promise<T> {
+    get<T>(request: IReturn<T>|string, args?:any, signal?:AbortSignal): Promise<T> {
         return typeof request != "string" 
-            ? this.send<T>(HttpMethods.Get, request, args)
-            : this.send<T>(HttpMethods.Get, null, args, this.toAbsoluteUrl(request));
+            ? this.send<T>(HttpMethods.Get, request, args, null, signal)
+            : this.send<T>(HttpMethods.Get, null, args, this.toAbsoluteUrl(request), signal);
     }
 
-    delete<T>(request: IReturn<T>|string, args?:any): Promise<T> {
+    delete<T>(request: IReturn<T>|string, args?:any, signal?:AbortSignal): Promise<T> {
         return typeof request != "string" 
-            ? this.send<T>(HttpMethods.Delete, request, args)
-            : this.send<T>(HttpMethods.Delete, null, args, this.toAbsoluteUrl(request));
+            ? this.send<T>(HttpMethods.Delete, request, args, null, signal)
+            : this.send<T>(HttpMethods.Delete, null, args, this.toAbsoluteUrl(request), signal);
     }
 
-    post<T>(request: IReturn<T>, args?:any): Promise<T> {
-        return this.send<T>(HttpMethods.Post, request, args);
+    post<T>(request: IReturn<T>, args?:any, signal?:AbortSignal): Promise<T> {
+        return this.send<T>(HttpMethods.Post, request, args, null, signal);
     }
 
-    postToUrl<T>(url:string, request:IReturn<T>, args?:any): Promise<T> {
-        return this.send<T>(HttpMethods.Post, request, args, this.toAbsoluteUrl(url));
+    postToUrl<T>(url:string, request:IReturn<T>, args?:any, signal?:AbortSignal): Promise<T> {
+        return this.send<T>(HttpMethods.Post, request, args, this.toAbsoluteUrl(url), signal);
     }
 
-    postBody<T>(request:IReturn<T>, body:string|any, args?:any) {
-        return this.sendBody<T>(HttpMethods.Post, request, body, args);
+    postBody<T>(request:IReturn<T>, body:string|any, args?:any, signal?:AbortSignal) {
+        return this.sendBody<T>(HttpMethods.Post, request, body, args, signal);
     }
 
-    put<T>(request: IReturn<T>, args?:any): Promise<T> {
-        return this.send<T>(HttpMethods.Put, request, args);
+    put<T>(request: IReturn<T>, args?:any, signal?:AbortSignal): Promise<T> {
+        return this.send<T>(HttpMethods.Put, request, args, null, signal);
     }
 
-    putToUrl<T>(url:string, request:IReturn<T>, args?:any): Promise<T> {
-        return this.send<T>(HttpMethods.Put, request, args, this.toAbsoluteUrl(url));
+    putToUrl<T>(url:string, request:IReturn<T>, args?:any, signal?:AbortSignal): Promise<T> {
+        return this.send<T>(HttpMethods.Put, request, args, this.toAbsoluteUrl(url), signal);
     }
 
-    putBody<T>(request:IReturn<T>, body:string|any, args?:any) {
-        return this.sendBody<T>(HttpMethods.Put, request, body, args);
+    putBody<T>(request:IReturn<T>, body:string|any, args?:any, signal?:AbortSignal) {
+        return this.sendBody<T>(HttpMethods.Put, request, body, args, signal);
     }
 
-    patch<T>(request: IReturn<T>, args?:any): Promise<T> {
-        return this.send<T>(HttpMethods.Patch, request, args);
+    patch<T>(request: IReturn<T>, args?:any, signal?:AbortSignal): Promise<T> {
+        return this.send<T>(HttpMethods.Patch, request, args, null, signal);
     }
 
-    patchToUrl<T>(url:string, request:IReturn<T>, args?:any): Promise<T> {
-        return this.send<T>(HttpMethods.Patch, request, args, this.toAbsoluteUrl(url));
+    patchToUrl<T>(url:string, request:IReturn<T>, args?:any, signal?:AbortSignal): Promise<T> {
+        return this.send<T>(HttpMethods.Patch, request, args, this.toAbsoluteUrl(url), signal);
     }
 
-    patchBody<T>(request:IReturn<T>, body:string|any, args?:any) {
-        return this.sendBody<T>(HttpMethods.Patch, request, body, args);
+    patchBody<T>(request:IReturn<T>, body:string|any, args?:any, signal?:AbortSignal) {
+        return this.sendBody<T>(HttpMethods.Patch, request, body, args, signal);
     }
 
-    publish(request: IReturnVoid, args?:any): Promise<any> {
-        return this.sendOneWay(request, args);
+    publish(request: IReturnVoid, args?:any, signal?:AbortSignal): Promise<any> {
+        return this.sendOneWay(request, args, signal);
     }
     
-    sendOneWay<T>(request: IReturn<T>|IReturnVoid, args?:any): Promise<T> {
+    sendOneWay<T>(request: IReturn<T>|IReturnVoid, args?:any, signal?:AbortSignal): Promise<T> {
         const url = combinePaths(this.oneWayBaseUrl, nameOf(request));
-        return this.send<T>(HttpMethods.Post, request, null, url);
+        return this.send<T>(HttpMethods.Post, request, null, url, signal);
     }
 
-    sendAll<T>(requests:IReturn<T>[]) : Promise<T[]> {
+    sendAll<T>(requests:IReturn<T>[], signal?: AbortSignal) : Promise<T[]> {
         if (requests.length == 0)
             return Promise.resolve([]);
 
         const url = combinePaths(this.replyBaseUrl, nameOf(requests[0]) + "[]");
-        return this.send<T[]>(HttpMethods.Post, requests, null, url);
+        return this.send<T[]>(HttpMethods.Post, requests, null, url, signal);
     }
 
-    sendAllOneWay<T>(requests:IReturn<T>[]) : Promise<void> {
+    sendAllOneWay<T>(requests:IReturn<T>[], signal?: AbortSignal) : Promise<void> {
         if (requests.length == 0)
             return Promise.resolve(void 0);
 
         const url = combinePaths(this.oneWayBaseUrl, nameOf(requests[0]) + "[]");
-        return this.send<T[]>(HttpMethods.Post, requests, null, url)
+        return this.send<T[]>(HttpMethods.Post, requests, null, url, signal)
             .then(r => void 0);
     }
 
@@ -900,7 +901,7 @@ export class JsonServiceClient {
         }
     }
 
-    private createRequest({ method, request, url, args, body } : ISendRequest) : IRequestInit {
+    private createRequest({ method, request, url, args, body, signal } : ISendRequest) : IRequestInit {
 
         if (!url)
             url = this.createUrlFromDto(method, request);
@@ -939,6 +940,7 @@ export class JsonServiceClient {
             credentials: this.credentials,
             headers,
             compress: false,  // https://github.com/bitinn/node-fetch/issues/93#issuecomment-200791658
+            signal: signal
         };
 
         if (hasRequestBody) {
@@ -1050,11 +1052,11 @@ export class JsonServiceClient {
         });
     }
 
-    send<T>(method:string, request:any|null, args?:any, url?:string): Promise<T> {
-        return this.sendRequest<T>({ method, request, args, url });
+    send<T>(method:string, request:any|null, args?:any, url?:string, signal?:AbortSignal): Promise<T> {
+        return this.sendRequest<T>({ method, request, args, url, signal });
     }
 
-    private sendBody<T>(method:string, request:IReturn<T>, body:string|any, args?:any) {
+    private sendBody<T>(method:string, request:IReturn<T>, body:string|any, args?:any, signal?:AbortSignal) {
         let url = combinePaths(this.replyBaseUrl, nameOf(request));
         return this.sendRequest<T>({
             method,
@@ -1066,7 +1068,8 @@ export class JsonServiceClient {
                     : JSON.stringify(body),
             url: appendQueryString(url, request), 
             args,
-            returns: request 
+            returns: request ,
+            signal: signal
         });
     }
 

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -20,6 +20,8 @@ import {
     appendQueryString,
 } from  '../src/index';
 
+import AbortController from "abort-controller"
+
 declare var process:any;
 
 const expect = chai.expect; 
@@ -522,5 +524,52 @@ describe ('JsonServiceClient Tests', () => {
         testClient.urlFilter = null;
     })
 
+    it ('Can abort GET IReturnVoid requests', done => {
+        let request = new HelloReturnVoid();
+        request.id = 1;
+
+        let controller = new AbortController();
+        const signal = controller.signal;
+
+
+        var testPromise = new Promise((resolve,reject) => {
+            testClient.get(request, {signal} ).then(response => {
+                reject(response);
+            }).catch((error) => {
+                resolve(error);
+            })
+        });
+        controller.abort();
+
+        testPromise.then((res: ErrorResponse) => {
+            console.log(JSON.stringify(res));
+            try {
+                chai.expect(res.responseStatus.errorCode).to.be.equal('AbortException');
+                //chai.expect(res.responseStatus.message).to.be.equal('Invalid Username or Password');
+                done();
+            } catch(error) {
+                done(error);
+            }
+        },done);
+
+
+        // testClient.get(request, {signal} )
+        //     .then(r => throw, 
+        //     error => {
+
+        //         done();
+        //     });
+
+        //     testPromise.then((res: ErrorResponse) => {
+        //         try {
+        //             chai.expect(res.responseStatus.errorCode).to.be.equal('NotImplementedException');
+        //             chai.expect(res.responseStatus.message).to.be.equal('The operation \'Overview\' does not exist for this service');
+        //             done();
+        //         } catch(error) {
+        //             done(error);
+        //         }
+        //     },done);
+
+    })
 });
 

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -533,7 +533,7 @@ describe ('JsonServiceClient Tests', () => {
 
 
         var testPromise = new Promise((resolve,reject) => {
-            testClient.get(request, {signal} ).then(response => {
+            testClient.get(request, null, signal).then(response => {
                 reject(response);
             }).catch((error) => {
                 resolve(error);


### PR DESCRIPTION
To address UserVoice request Support AbortController API in servicestack-client, and to add a feature analogous to AxiosJS's cancellation, this PR adds support for an optional request config parameter signal, of type AbortSignal.

This is a cleanup & reissue of PR #19 

Example usage:

let controller = new AbortController();
const signal = controller.signal;

let client = new JsonServiceClient(...)
let result = client.get(request, null, signal )
    .then(response => {})
    .catch((error) => {})

signal.abort();