### PR TITLE
More explicit node detection due to cases like e2e testing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ declare let require:Function;
 function nodeRequire() {
     //node require(), using dynamic access to fix web ng aot build
     try {
-        return typeof window !== 'undefined' ? null : (typeof require !== 'undefined' ? require : null);
+        let isNode = typeof process === 'object' &&
+            typeof process.versions === 'object' &&
+            typeof process.versions.node !== 'undefined';
+        if(isNode) return require;
+        return null;
     } catch (e) { return null; }
 }
 let R = nodeRequire();


### PR DESCRIPTION
More explicit node detection due to cases like e2e testing having `window` but not mocking everything for a browser, eg `Headers`.