### PR TITLE
Fix umd file exports require in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/servicestack-client.mjs",
-      "require": "./dist/servicestack-client.umd"
+      "require": "./dist/servicestack-client.umd.js"
     }
   },
   "engines": {


### PR DESCRIPTION
Causing issues with node + module == commonjs setup as just "./dist/servicestack-client.umd" doesn't exist, but "./dist/servicestack-client.umd.js" does.